### PR TITLE
Solving deprecation Warning on newest Sinatra release when using options method. 

### DIFF
--- a/lib/sinatra/static_assets.rb
+++ b/lib/sinatra/static_assets.rb
@@ -47,7 +47,7 @@ module Sinatra
           content = yield
           "#{start_tag}>#{content}</#{name}>"
         else
-          "#{start_tag}#{"/" if options.xhtml}>"
+          "#{start_tag}#{"/" if setting.xhtml}>"
         end
       end
 


### PR DESCRIPTION
Sinatra::Base#options is deprecated and will be removed, use #settings instead.
